### PR TITLE
Add `transform` hook

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,0 +1,10 @@
+# This file is auto-synced from product-os/jellyfish-config/.resinci.yml
+# and should only be edited there!
+
+npm:
+  platforms:
+    - name: linux
+      os: alpine
+      architecture: x86_64
+      node_versions:
+        - "16"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# transformer-sdk
+
+Transformer SDK handles transformer bootstrap and IO so that implementing a transformer is easy.
+
+Import the SDK:
+
+`import * as sdk from 'transformer-sdk'`
+
+Implement the transformation function, pass it to `sdk.transform` hook:
+
+```
+sdk.transform(manifest => {
+	// implement transformation
+	return results
+}
+```
+
+

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as YAML from 'yaml';
+import type { Contract } from '@balena/jellyfish-types/build/core';
+import { InputManifest, Results } from './types';
+
+// export types for use by transformers
+export * from './types';
+// export yaml tag to help write inputFilter yaml in js
+export * as yaml from 'yaml-tag';
+
+export async function transform<InputContract extends Contract = Contract>(
+	callback: (manifest: InputManifest<InputContract>) => Promise<Results>,
+) {
+	const inputPath = getEnvOrFail('INPUT');
+	const outputPath = getEnvOrFail('OUTPUT');
+	const manifest = await readInput<InputContract>(inputPath);
+	const results = await callback(manifest);
+	await writeOutput(outputPath, results);
+}
+
+async function readInput<InputContract extends Contract = Contract>(
+	inputPath: string,
+) {
+	const inputDir = path.dirname(inputPath);
+	const manifest: InputManifest<InputContract> = YAML.parse(
+		(await fs.promises.readFile(inputPath)).toString(),
+	);
+	// make path absolute to make handling for users easier
+	manifest.input.artifactPath = path.join(
+		inputDir,
+		manifest.input.artifactPath,
+	);
+	return manifest;
+}
+
+async function writeOutput(outputPath: string, results: Results) {
+	await fs.promises.writeFile(outputPath, JSON.stringify(results));
+}
+
+function getEnvOrFail(envVar: string) {
+	const env = process.env[envVar];
+	if (!env) {
+		console.log(`required env var ${envVar} was not set`);
+		process.exit(1);
+	}
+	return env;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,30 @@
+import type { Contract } from '@balena/jellyfish-types/build/core';
+
+export interface TransformerContract
+	extends Contract<{
+		targetPlatform?: string;
+	}> {}
+
+export type InputManifest<InputContract extends Contract = Contract> = {
+	input: {
+		contract: InputContract;
+		transformerContract: TransformerContract;
+		artifactPath: string; // relative to the input file
+		decryptedSecrets?: {
+			[key: string]: string;
+		};
+		decryptedTransformerSecrets?: {
+			[key: string]: string;
+		};
+	};
+};
+
+export type Results = {
+	results: Result[];
+};
+
+export type Result<ResultContract extends Contract = Contract> = {
+	contract: ResultContract;
+	artifactPath?: string; // relative to the results file
+	imagePath?: string; // relative to the results file
+};

--- a/lib/yaml-tag.d.ts
+++ b/lib/yaml-tag.d.ts
@@ -1,0 +1,3 @@
+declare module 'yaml-tag' {
+	export default function (strings: TemplateStringsArray): unknown;
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "transformer-sdk",
+  "name": "@balena/transformer-sdk",
   "version": "0.1",
   "description": "Provides hooks, types and utils for developing transformers",
   "homepage": "https://github.com/product-os/transformer-sdk#readme",

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -1,0 +1,45 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as sdk from '../lib';
+
+import type { InputManifest } from '../lib';
+import type { Contract } from '@balena/jellyfish-types/build/core';
+
+interface TestContract
+	extends Contract<{
+		exists: true;
+	}> {}
+
+describe('Transformer SDK', function () {
+	const inputManifest: InputManifest<TestContract> = {
+		input: {
+			contract: { slug: 'test', type: 'test', data: { exists: true } } as any,
+			transformerContract: {} as any,
+			artifactPath: 'artifact',
+		},
+	};
+
+	beforeEach(() => {
+		const inputDir = fs.mkdtempSync(path.join(os.tmpdir(), path.sep));
+		const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), path.sep));
+		process.env['INPUT'] = path.join(inputDir, 'input-manifest.yml');
+		process.env['OUTPUT'] = path.join(outputDir, 'output-manifest.yml');
+		fs.writeFileSync(
+			process.env['INPUT'] as string,
+			JSON.stringify(inputManifest),
+		);
+	});
+
+	afterEach(() => {
+		Reflect.deleteProperty(process.env, 'INPUT');
+		Reflect.deleteProperty(process.env, 'OUTPUT');
+	});
+
+	it('should execute transform callback', async function () {
+		await sdk.transform<TestContract>((manifest) => {
+			expect(manifest.input.contract.data.exists).toEqual(true);
+			return Promise.resolve({ results: [] });
+		});
+	});
+});


### PR DESCRIPTION
SDK to handle transform bootstrap and IO. 

Adds transform hook, executes callback with input manifest read from disk, writes return value to expected output directory.

cc @cmfcruz @dfunckt @LucianBuzzo 

Change-type: minor