### PR TITLE
Remove yaml tag

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,13 +1,11 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as YAML from 'yaml';
+import * as yaml from 'js-yaml';
 import type { Contract } from '@balena/jellyfish-types/build/core';
 import { InputManifest, Results } from './types';
 
 // export types for use by transformers
 export * from './types';
-// export yaml tag to help write inputFilter yaml in js
-export * as yaml from 'yaml-tag';
 
 export async function transform<InputContract extends Contract = Contract>(
 	callback: (manifest: InputManifest<InputContract>) => Promise<Results>,
@@ -23,9 +21,9 @@ async function readInput<InputContract extends Contract = Contract>(
 	inputPath: string,
 ) {
 	const inputDir = path.dirname(inputPath);
-	const manifest: InputManifest<InputContract> = YAML.parse(
+	const manifest = yaml.load(
 		(await fs.promises.readFile(inputPath)).toString(),
-	);
+	) as  InputManifest<InputContract>;
 	// make path absolute to make handling for users easier
 	manifest.input.artifactPath = path.join(
 		inputDir,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,5 @@
 import type { Contract } from '@balena/jellyfish-types/build/core';
+export type { Contract } from '@balena/jellyfish-types/build/core';
 
 export interface TransformerContract
 	extends Contract<{

--- a/lib/yaml-tag.d.ts
+++ b/lib/yaml-tag.d.ts
@@ -1,3 +1,0 @@
-declare module 'yaml-tag' {
-	export default function (strings: TemplateStringsArray): unknown;
-}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
-    "js-yaml": "^4.1.0",
-    "yaml-tag": "^1.1.0"
+    "js-yaml": "^4.1.0"
   }
 }


### PR DESCRIPTION
Remove yaml tag function, yaml is indentation sensitive and indentation hard to control with template literals, could be very hard for a user to get right, not a good helper.

Change-type: minor